### PR TITLE
Revert "Add Linux arm64 support (#262)"

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,9 +47,6 @@ jobs:
       if: startsWith(github.ref, 'refs/tags/')
     - run: yarn dist
       env:
-        # disable multipass
-        # ref: https://github.com/electron-userland/electron-builder/issues/4903#issuecomment-671010636
-        SNAPCRAFT_BUILD_ENVIRONMENT: host
         CI: true
         CI_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dist.js
+++ b/dist.js
@@ -69,7 +69,7 @@ switch (process.platform) {
   }
   default:
   case 'linux': {
-    targets = Platform.LINUX.createTarget(['AppImage', 'snap'], Arch.x64, Arch.arm64);
+    targets = Platform.LINUX.createTarget(['AppImage', 'snap']);
     break;
   }
 }


### PR DESCRIPTION
This reverts commit b11b91fcc6c3861dabb8a141e3413d5488e02e6a.

Fix "snapcraft does not currently support building arm64 on amd64"